### PR TITLE
fix(docker): fix ghcr/quay/gcr/k8s pulls that never actually worked

### DIFF
--- a/src/tools/docker.js
+++ b/src/tools/docker.js
@@ -78,19 +78,35 @@ export default {
         // 5. 路由解析逻辑
         let upstream = DEFAULT_UPSTREAM;
         let pathParts = url.pathname.split('/');
-        let potentialRoute = pathParts[1]; // 获取第一个路径段，如 /quay/...
-        
+        let potentialRoute = pathParts[1]; // 获取第一个路径段，如 /quay/v2/...
+        // 真实 docker 客户端请求形如 /v2/ghcr/yusing/godoxy/manifests/latest，
+        // 路由前缀出现在 /v2/ 之后而非路径最开头，需要单独识别
+        let v2RoutePrefix = potentialRoute === 'v2' ? pathParts[2] : null;
+
         if (ROUTES[potentialRoute]) {
-            // 命中路由表 (例如 quay, gcr)
+            // 命中路由表 (虚拟主机前缀形式，例如 /quay/v2/...)
             upstream = ROUTES[potentialRoute];
             url.pathname = url.pathname.replace(`/${potentialRoute}`, '');
+        } else if (v2RoutePrefix && ROUTES[v2RoutePrefix]) {
+            // 命中路由表 (真实 docker pull 形式，例如 /v2/ghcr/yusing/godoxy/manifests/latest)
+            upstream = ROUTES[v2RoutePrefix];
+            url.pathname = url.pathname.replace(`/v2/${v2RoutePrefix}`, '/v2');
         } else {
-            // 默认为 Docker Hub，处理 Token 和 Library 补全
+            // 处理 Token 请求：优先使用上游在 Www-Authenticate 中声明的真实 realm
+            // (通过 __realm 参数回传，见下方第 8 步)，否则回退到 Docker Hub 的认证服务器
             if (url.pathname.includes('/token')) {
-                const tokenUrl = new URL("https://auth.docker.io" + url.pathname + url.search);
+                const explicitRealm = url.searchParams.get('__realm');
+                const tokenUrl = explicitRealm
+                    ? new URL(explicitRealm)
+                    : new URL("https://auth.docker.io" + url.pathname);
+                for (const [key, value] of url.searchParams) {
+                    if (key === '__realm') continue;
+                    tokenUrl.searchParams.set(key, value);
+                }
+
                 const scope = tokenUrl.searchParams.get('scope');
-                // 自动补全 library 权限 (pull nginx -> pull library/nginx)
-                if (scope) {
+                // 自动补全 library 权限 (pull nginx -> pull library/nginx)，仅对 Docker Hub 生效
+                if (!explicitRealm && scope) {
                     const scopeParts = scope.split(':');
                     if (scopeParts.length === 3 && scopeParts[0] === 'repository' && !scopeParts[1].includes('/')) {
                         const newScope = `repository:library/${scopeParts[1]}:${scopeParts[2]}`;
@@ -127,10 +143,15 @@ export default {
         const responseHeaders = new Headers(response.headers);
         const status = response.status;
 
-        // 8. 修改 Www-Authenticate 头 (指向 Worker)
+        // 8. 修改 Www-Authenticate 头 (指向 Worker)，非 Docker Hub 上游需回传真实 realm
+        // 供 /token 处理逻辑区分认证服务器 (见上方第 5 步)
         const authHeader = responseHeaders.get("Www-Authenticate");
         if (authHeader) {
-            responseHeaders.set("Www-Authenticate", authHeader.replace(/realm="([^"]+)"/, `realm="${workerUrl}/token"`));
+            const realmMatch = authHeader.match(/realm="([^"]+)"/);
+            const proxiedRealm = realmMatch && upstream !== DEFAULT_UPSTREAM
+                ? `${workerUrl}/token?__realm=${encodeURIComponent(realmMatch[1])}`
+                : `${workerUrl}/token`;
+            responseHeaders.set("Www-Authenticate", authHeader.replace(/realm="([^"]+)"/, `realm="${proxiedRealm}"`));
         }
 
         // 9. 【核心修复】拦截 S3 重定向


### PR DESCRIPTION
Docker 工具的 README 和 ROUTES 路由表都声称支持 ghcr、quay、gcr、k8s、cloudsmith 和 nvcr 这些镜像仓库，但实际从这些仓库拉取镜像时都会默默回退到 Docker Hub 并失败，原因是两个 bug：

  - docker pull 发出的请求路径格式是 /v2/{route}/{image}/...，而不是 {route}/v2/{image}/...，导致别名路由逻辑取到的路径第一段永远是 "v2"，从未真正匹配上 ROUTES 表里的任何条目。
  - Token 交换逻辑被硬编码为始终请求 auth.docker.io，即使这个 401 认证挑战实际上来自其他仓库自己的 token 服务。

这次修复解决了以上两个问题：别名路由逻辑现在也能识别嵌套在 /v2/ 之后的路由前缀；同时改写后的 Www-Authenticate 头会通过 __realm 参数把发起挑战的仓库的真实 realm 传递下去，使得 token 交换请求能发到正确的认证服务器。


bug复现：

按照官方示例，尝试加速如下docker镜像
`ghcr.io/yusing/godoxy:latest`
得到地址
`docker pull box.w0x7ce.eu/ghcr/yusing/godoxy:latest`

```
Error response from daemon: pull access denied for box.w0x7ce.eu/ghcr/yusing/godoxy, repository does not exist or may require 'docker login'
```
---

The docker tool's README and ROUTES table both advertise ghcr, quay, gcr, k8s, cloudsmith, and nvcr as supported registries, but pulling from any of them silently fell back to Docker Hub and failed, due to two bugs:

- docker pull sends repository paths as /v2/{route}/{image}/... not {route}/v2/{image}/..., so the alias router only ever saw "v2" as the first path segment and never matched an entry in ROUTES.
- Token exchange was hardcoded to always call auth.docker.io, even when the 401 challenge came from a different registry's own token service.

This fixes both: the alias router now also recognizes routes nested under /v2/, and the rewritten Www-Authenticate header propagates the challenging registry's real realm (via a __realm param) so token exchange goes to the correct auth server.